### PR TITLE
Revamp portfolio layout with placeholder design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Portfolio
 
-This repository contains a minimal React setup for a portfolio site. It uses Vite for development and includes basic components you can style and expand.
+This repository contains a simple React design portfolio built with Vite. It features a hero section, sample project cards, and a contact form so you can quickly showcase your work.
 
 ## Available Scripts
 

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -4,7 +4,11 @@ function About() {
   return (
     <section id="about">
       <h2>About Me</h2>
-      <p>This is a short bio where you can introduce yourself.</p>
+      <p>
+        I'm a multidisciplinary designer focused on delivering engaging and
+        memorable digital experiences. This placeholder bio highlights design
+        skills and approach.
+      </p>
     </section>
   );
 }

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -3,18 +3,18 @@ import React from 'react';
 function Contact() {
   return (
     <section id="contact">
-      <h2>Contact</h2>
+      <h2>Let's Connect</h2>
       <form>
         <label htmlFor="name">Name</label>
-        <input type="text" id="name" />
+        <input type="text" id="name" placeholder="Your name" />
 
         <label htmlFor="email">Email</label>
-        <input type="email" id="email" />
+        <input type="email" id="email" placeholder="you@example.com" />
 
         <label htmlFor="message">Message</label>
-        <textarea id="message" />
+        <textarea id="message" placeholder="How can I help?" />
 
-        <button type="submit">Send</button>
+        <button type="submit">Send Message</button>
       </form>
     </section>
   );

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 function Footer() {
   return (
     <footer>
-      <p>&copy; 2025 My Portfolio</p>
+      <p>&copy; 2025 Jane Doe. All rights reserved.</p>
     </footer>
   );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 
 function Header() {
   return (
-    <header>
-      <h1>My Portfolio</h1>
+    <header className="hero">
+      <h1>Jane Doe Portfolio</h1>
+      <p className="tagline">Crafting intuitive digital experiences</p>
       <nav>
         <ul>
           <li><a href="#about">About</a></li>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,14 +1,39 @@
 import React from 'react';
 
 function Projects() {
+  const items = [
+    {
+      id: 1,
+      title: 'Brand Identity',
+      img: 'https://source.unsplash.com/random/800x600?sig=1&design',
+    },
+    {
+      id: 2,
+      title: 'Website Redesign',
+      img: 'https://source.unsplash.com/random/800x600?sig=2&ui',
+    },
+    {
+      id: 3,
+      title: 'Mobile App',
+      img: 'https://source.unsplash.com/random/800x600?sig=3&app',
+    },
+  ];
+
   return (
     <section id="projects">
-      <h2>Projects</h2>
-      <ul>
-        <li>Project 1</li>
-        <li>Project 2</li>
-        <li>Project 3</li>
-      </ul>
+      <h2>Selected Works</h2>
+      <div className="projects-grid">
+        {items.map((item) => (
+          <div className="project-card" key={item.id}>
+            <img src={item.img} alt="" />
+            <h3>{item.title}</h3>
+            <p>
+              Brief description of this project highlighting design goals and
+              results.
+            </p>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,77 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  line-height: 1.6;
+  color: #333;
+  background-color: #f8f8f8;
+}
+
+header.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+  background: #fafafa;
+}
+
+header.hero h1 {
+  font-size: 3rem;
+  margin-bottom: 0.5rem;
+}
+
+header.hero .tagline {
+  font-size: 1.25rem;
+  color: #666;
+  margin-bottom: 2rem;
+}
+
+nav ul {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 0;
+  list-style: none;
+  margin: 0;
+}
+
+nav a {
+  color: #333;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+main {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+section {
+  margin-bottom: 4rem;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.project-card {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.project-card img {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: #333;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- style site with a new CSS file
- add hero header, updated about and contact sections
- showcase placeholder projects in a grid
- update footer and README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6bc41be08331a8a518d6aded5ddf